### PR TITLE
Update to use master branch for `mocha-w3c-interop-reporter`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "jsonld-document-loader": "^1.2.0",
     "klona": "^2.0.5",
     "mocha": "^9.1.3",
-    "mocha-w3c-interop-reporter": "github:digitalbazaar/mocha-w3c-interop-reporter#add-more-status-marks",
+    "mocha-w3c-interop-reporter": "github:digitalbazaar/mocha-w3c-interop-reporter",
     "require-dir": "^1.2.0",
     "uuid": "^8.3.2",
     "vc-api-test-suite-implementations": "github:w3c-ccg/vc-api-test-suite-implementations"


### PR DESCRIPTION
This is the last test suite using `add-more-status-marks` branch