### PR TITLE
Use next implementations

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "mocha": "^9.1.3",
     "require-dir": "^1.2.0",
     "uuid": "^8.3.2",
-    "vc-api-test-suite-implementations": "github:w3c-ccg/vc-api-test-suite-implementations#add-endpoint-class"
+    "vc-api-test-suite-implementations": "github:w3c-ccg/vc-api-test-suite-implementations"
   },
   "devDependencies": {
     "eslint": "^7.23.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@digitalbazaar/did-method-key": "^2.0.0",
     "@digitalbazaar/ed25519-signature-2020": "^3.0.0",
     "@digitalbazaar/http-client": "^2.0.1",
+    "@digitalbazaar/mocha-w3c-interop-reporter": "^1.2.0",
     "@digitalbazaar/vc": "^2.1.0",
     "@digitalbazaar/vc-status-list": "^2.1.0",
     "@digitalbazaar/vc-status-list-context": "^2.0.0",
@@ -42,10 +43,9 @@
     "jsonld-document-loader": "^1.2.0",
     "klona": "^2.0.5",
     "mocha": "^9.1.3",
-    "@digitalbazaar/mocha-w3c-interop-reporter": "^1.2.0",
     "require-dir": "^1.2.0",
     "uuid": "^8.3.2",
-    "vc-api-test-suite-implementations": "github:w3c-ccg/vc-api-test-suite-implementations"
+    "vc-api-test-suite-implementations": "github:w3c-ccg/vc-api-test-suite-implementations#add-endpoint-class"
   },
   "devDependencies": {
     "eslint": "^7.23.0",

--- a/tests/10-issue.js
+++ b/tests/10-issue.js
@@ -42,7 +42,7 @@ describe('StatusList2021 Credentials (Issue)', function() {
           date.setMonth(date.getMonth() + 2);
           return ISOTimeStamp({date});
         };
-        const {issuer: {id: issuerId}} = issuer;
+        const {settings: {id: issuerId}} = issuer;
         const body = {
           credential: {
             ...validVc,
@@ -52,7 +52,7 @@ describe('StatusList2021 Credentials (Issue)', function() {
             issuer: issuerId
           }
         };
-        const {result, error} = await issuer.issue({body});
+        const {result, error} = await issuer.post({json: body});
         issuerResponse = result;
         err = error;
         if(issuerResponse) {

--- a/tests/10-issue.js
+++ b/tests/10-issue.js
@@ -15,7 +15,10 @@ const {validVc} = require('../credentials');
 const should = chai.should();
 
 // only use implementations with `StatusList2021` issuers.
-const {match, nonMatch} = filterByTag({issuerTags: ['RevocationList2020']});
+const {match, nonMatch} = filterByTag({
+  property: 'issuers',
+  tags: ['RevocationList2020']
+});
 
 describe('StatusList2021 Credentials (Issue)', function() {
   // this will tell the report

--- a/tests/20-verify.js
+++ b/tests/20-verify.js
@@ -14,7 +14,10 @@ const validVc = require('../static-vcs/validVc.json');
 const should = chai.should();
 
 // only use implementations with `StatusList2021` verifiers.
-const {match, nonMatch} = filterByTag({verifierTags: ['StatusList2021']});
+const {match, nonMatch} = filterByTag({
+  property: 'verifiers',
+  tags: ['StatusList2021']
+});
 
 describe('StatusList2021 Credentials (Verify)', function() {
   // this will tell the report

--- a/tests/20-verify.js
+++ b/tests/20-verify.js
@@ -43,7 +43,7 @@ describe('StatusList2021 Credentials (Verify)', function() {
               checks: ['proof', 'credentialStatus']
             }
           };
-          const {result, error} = await verifier.verify({body});
+          const {result, error} = await verifier.post({json: body});
           should.exist(result);
           should.not.exist(error);
         });
@@ -58,7 +58,7 @@ describe('StatusList2021 Credentials (Verify)', function() {
             checks: ['proof', 'credentialStatus']
           }
         };
-        const {result, error} = await verifier.verify({body});
+        const {result, error} = await verifier.post({json: body});
         should.not.exist(result);
         should.exist(error);
         should.exist(error.data);
@@ -80,7 +80,7 @@ describe('StatusList2021 Credentials (Verify)', function() {
               checks: ['proof', 'credentialStatus']
             }
           };
-          const {result, error} = await verifier.verify({body});
+          const {result, error} = await verifier.post({json: body});
           should.not.exist(result);
           should.exist(error);
           should.exist(error.data);

--- a/tests/30-interop.js
+++ b/tests/30-interop.js
@@ -69,7 +69,7 @@ describe('StatusList2021 Credentials (Interop)', function() {
               checks: ['proof', 'credentialStatus']
             }
           };
-          const {result, error} = await verifier.verify({body});
+          const {result, error} = await verifier.post({json: body});
           should.exist(result);
           should.not.exist(error);
           // verifier returns 200
@@ -103,8 +103,8 @@ describe('StatusList2021 Credentials (Interop)', function() {
               checks: ['proof', 'credentialStatus']
             }
           };
-          const {result: result1, error: err1} = await verifier.verify(
-            {body});
+          const {result: result1, error: err1} = await verifier.post(
+            {json: body});
           should.exist(result1);
           should.not.exist(err1);
           result1.status.should.equal(200);
@@ -150,8 +150,8 @@ describe('StatusList2021 Credentials (Interop)', function() {
               checks: ['proof', 'credentialStatus']
             }
           };
-          const {result: result4, error: err4} = await verifier.verify(
-            {body: body3});
+          const {result: result4, error: err4} = await verifier.post(
+            {json: body3});
           should.not.exist(result4);
           should.exist(err4);
           should.exist(err4.data);

--- a/tests/30-interop.js
+++ b/tests/30-interop.js
@@ -13,7 +13,10 @@ const {validVc} = require('../credentials');
 const should = chai.should();
 
 // only use implementations with `StatusList2021` tags.
-const {match, nonMatch} = filterByTag({issuerTags: ['RevocationList2020']});
+const {match, nonMatch} = filterByTag({
+  property: 'issuers',
+  tags: ['RevocationList2020']
+});
 
 describe('StatusList2021 Credentials (Interop)', function() {
   // this will tell the report

--- a/tests/30-interop.js
+++ b/tests/30-interop.js
@@ -28,7 +28,7 @@ describe('StatusList2021 Credentials (Interop)', function() {
   this.columnLabel = 'Implementation';
   this.notImplemented = [...nonMatch.keys()];
   // the reportData will be displayed under the test title
-  for(const [issuerName, {issuers}] of match) {
+  for(const [issuerName, {issuers, statusLists, publishStatusLists}] of match) {
     let issuedVc;
     before(async function() {
       const issuer = issuers.find(issuer =>
@@ -114,7 +114,9 @@ describe('StatusList2021 Credentials (Interop)', function() {
           result1.data.verified.should.equal(true);
           result1.data.statusResult.verified.should.equal(true);
 
-          const issuer = issuers.find(issuer =>
+          const statusList = statusLists.find(issuer =>
+            issuer.tags.has('RevocationList2020'));
+          const publishList = publishStatusLists.find(issuer =>
             issuer.tags.has('RevocationList2020'));
           const body2 = {
             credentialId: vc.id,
@@ -123,16 +125,16 @@ describe('StatusList2021 Credentials (Interop)', function() {
             }
           };
             // Then revoke the VC
-          const {result: result2, error: err2} = await issuer.setStatus(
-            {body: body2});
+          const {result: result2, error: err2} = await statusList.post(
+            {json: body2});
           should.not.exist(err2);
           should.exist(result2);
           result2.status.should.equal(200);
           const publishSlcEndpoint =
               `${statusInfo.statusListCredential}/publish`;
             // force publication of new SLC
-          const {result: result3, error: err3} = await issuer.publishSlc(
-            {endpoint: publishSlcEndpoint, body: {}});
+          const {result: result3, error: err3} = await publishList.post(
+            {url: publishSlcEndpoint, json: {}});
           should.not.exist(err3);
           should.exist(result3);
           result3.status.should.equal(204);

--- a/tests/30-interop.js
+++ b/tests/30-interop.js
@@ -38,7 +38,7 @@ describe('StatusList2021 Credentials (Interop)', function() {
         date.setMonth(date.getMonth() + 2);
         return ISOTimeStamp({date});
       };
-      const {issuer: {id: issuerId}} = issuer;
+      const {settings: {id: issuerId}} = issuer;
       const body = {
         credential: {
           ...validVc,
@@ -48,7 +48,7 @@ describe('StatusList2021 Credentials (Interop)', function() {
           issuer: issuerId
         }
       };
-      const {result} = await issuer.issue({body});
+      const {result} = await issuer.post({json: body});
       if(result) {
         issuedVc = result.data.verifiableCredential;
       }


### PR DESCRIPTION
https://github.com/w3c-ccg/vc-api-test-suite-implementations/pull/32

Replaces `issuer.issue` with `issuer.post` also uses endpoints with dedicated zcaps for `statusList` and `publishStatusList`.