### PR TITLE
Fixes interop tests report, moves tests for verification of revoked and suspended status list credentials into `verify.js` tests.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,14 +14,14 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install --legacy-peer-deps
+    - run: npm install
     - name: Run eslint
       run: npm run lint
   test-node:
@@ -30,17 +30,17 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           persist-credentials: false
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install npm dependencies
-        run: npm install --legacy-peer-deps
+        run: npm install
       - name: Run test with Node.js ${{ matrix.node-version }}
         env:
           KEY_SEED_DB: ${{ secrets.KEY_SEED_DB }}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@digitalbazaar/http-client": "^3.3.0",
-    "@digitalbazaar/mocha-w3c-interop-reporter": "^1.3.0",
+    "@digitalbazaar/mocha-w3c-interop-reporter": "digitalbazaar/mocha-w3c-interop-reporter",
     "@digitalbazaar/vc-status-list": "^7.0.0",
     "@digitalbazaar/vc-status-list-context": "^3.0.1",
     "@digitalcredentials/did-context": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "https://digitalbazaar.com/"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "dependencies": {
     "@digitalbazaar/http-client": "^3.3.0",

--- a/tests/10-issue.js
+++ b/tests/10-issue.js
@@ -10,7 +10,7 @@ import {filterByTag} from 'vc-api-test-suite-implementations';
 const should = chai.should();
 
 // only use implementations with `StatusList2021` issuers.
-const {match, nonMatch} = filterByTag({
+const {match} = filterByTag({
   property: 'issuers',
   tags: ['StatusList2021']
 });
@@ -21,7 +21,6 @@ describe('StatusList2021 Credentials (Issue "statusPurpose: revocation")',
     this.implemented = [...match.keys()];
     this.rowLabel = 'Test Name';
     this.columnLabel = 'Issuer';
-    this.notImplemented = [...nonMatch.keys()];
     for(const [issuerName, {issuers}] of match) {
       describe(issuerName, function() {
         let issuerResponse;
@@ -78,7 +77,6 @@ describe('StatusList2021 Credentials (Issue "statusPurpose: suspension")',
     this.implemented = [...match.keys()];
     this.rowLabel = 'Test Name';
     this.columnLabel = 'Issuer';
-    this.notImplemented = [...nonMatch.keys()];
     for(const [issuerName, {issuers}] of match) {
       describe(issuerName, function() {
         let issuerResponse;

--- a/tests/10-issue.js
+++ b/tests/10-issue.js
@@ -2,7 +2,7 @@
  * Copyright (c) 2022-2023 Digital Bazaar, Inc. All rights reserved.
  */
 import * as sl from '@digitalbazaar/vc-status-list';
-import {createValidVc, getSlc} from './helpers.js';
+import {getSlc, issueVc} from './helpers.js';
 import {testCredential, testSlCredential} from './assertions.js';
 import chai from 'chai';
 import {filterByTag} from 'vc-api-test-suite-implementations';
@@ -28,9 +28,7 @@ describe('StatusList2021 Credentials (Issue "statusPurpose: revocation")',
         let issuedVc;
         before(async function() {
           const issuer = issuers.find(issuer => issuer.tags.has('Revocation'));
-          const credential = createValidVc({issuer});
-          const {result, error, data} = await issuer.post({
-            json: {credential}});
+          const {result, error, data} = await issueVc({issuer});
           err = error;
           issuerResponse = result;
           issuedVc = data;
@@ -84,9 +82,7 @@ describe('StatusList2021 Credentials (Issue "statusPurpose: suspension")',
         let issuedVc;
         before(async function() {
           const issuer = issuers.find(issuer => issuer.tags.has('Suspension'));
-          const credential = createValidVc({issuer});
-          const {result, error, data} = await issuer.post({
-            json: {credential}});
+          const {result, error, data} = await issueVc({issuer});
           err = error;
           issuerResponse = result;
           issuedVc = data;

--- a/tests/20-verify.js
+++ b/tests/20-verify.js
@@ -8,7 +8,7 @@ import {shouldFailVerification, shouldPassVerification} from './assertions.js';
 import {klona} from 'klona';
 
 // only use implementations with `StatusList2021` verifiers.
-const {match, nonMatch} = filterByTag({
+const {match} = filterByTag({
   property: 'verifiers',
   tags: ['StatusList2021']
 });
@@ -19,7 +19,6 @@ describe('StatusList2021 Credentials (Verify)', function() {
   this.implemented = [...match.keys()];
   this.rowLabel = 'Test Name';
   this.columnLabel = 'Verifier';
-  this.notImplemented = [...nonMatch.keys()];
   for(const [verifierName, {verifiers}] of match) {
     describe(verifierName, function() {
       const verifier = verifiers.find(verifier =>

--- a/tests/30-interop.js
+++ b/tests/30-interop.js
@@ -11,7 +11,7 @@ import {klona} from 'klona';
 const should = chai.should();
 
 // only use implementations with `StatusList2021` tags.
-const {match, nonMatch} = filterByTag({
+const {match} = filterByTag({
   property: 'issuers',
   tags: ['StatusList2021']
 });
@@ -23,7 +23,6 @@ describe('StatusList2021 Credentials (Interop "statusPurpose: revocation")',
     this.implemented = [...match.keys()];
     this.rowLabel = 'Test Name';
     this.columnLabel = 'Implementation';
-    this.notImplemented = [...nonMatch.keys()];
     for(const [
       issuerName,
       {issuers, setStatusLists, publishStatusLists}
@@ -120,7 +119,6 @@ describe('StatusList2021 Credentials (Interop "statusPurpose: suspension")',
     this.implemented = [...match.keys()];
     this.rowLabel = 'Test Name';
     this.columnLabel = 'Implementation';
-    this.notImplemented = [...nonMatch.keys()];
     for(const [
       issuerName,
       {issuers, setStatusLists, publishStatusLists}

--- a/tests/30-interop.js
+++ b/tests/30-interop.js
@@ -1,112 +1,50 @@
 /*!
  * Copyright (c) 2022-2023 Digital Bazaar, Inc. All rights reserved.
  */
-import {createRequestBody, createValidVc, getCredentialStatus} from
-  './helpers.js';
-import {shouldFailVerification, shouldPassVerification} from './assertions.js';
+import {createRequestBody, issueVc} from './helpers.js';
 import chai from 'chai';
-import {filterByTag} from 'vc-api-test-suite-implementations';
-import {klona} from 'klona';
+import {endpoints} from 'vc-api-test-suite-implementations';
+import {shouldPassVerification} from './assertions.js';
 
 const should = chai.should();
 
 // only use implementations with `StatusList2021` tags.
-const {match} = filterByTag({
+const {match: issuerMatches} = endpoints.filterByTag({
   property: 'issuers',
+  tags: ['StatusList2021']
+});
+
+const {match: verifierMatches} = endpoints.filterByTag({
+  property: 'verifiers',
   tags: ['StatusList2021']
 });
 
 describe('StatusList2021 Credentials (Interop "statusPurpose: revocation")',
   function() {
+    // this will tell the report
+    // to make an interop matrix with this suite
     this.matrix = true;
     this.report = true;
-    this.implemented = [...match.keys()];
-    this.rowLabel = 'Test Name';
-    this.columnLabel = 'Implementation';
-    for(const [
-      issuerName,
-      {issuers, setStatusLists, publishStatusLists}
-    ] of match) {
+    this.implemented = [...verifierMatches.keys()];
+    this.rowLabel = 'Issuer';
+    this.columnLabel = 'Verifier';
+    for(const [issuerName, {endpoints}] of issuerMatches) {
       let issuedVc;
       before(async function() {
-        const issuer = issuers.find(issuer => issuer.tags.has('Revocation'));
-        const credential = createValidVc({issuer});
-        const body = {credential};
-        const {data} = await issuer.post({json: body});
-        issuedVc = data;
+        const [issuer] = endpoints.filter(
+          endpoint => endpoint.settings.tags.includes('Revocation'));
+        issuedVc = issueVc({issuer});
       });
-      for(const [verifierName, {verifiers}] of match) {
-        const verifier = verifiers.find(verifier =>
-          verifier.tags.has('StatusList2021'));
-        it(`MUST successfully verify VC issued by ${issuerName}`,
-          async function() {
-            this.test.cell = {columnId: verifierName, rowId: this.test.title};
-            const body = createRequestBody({vc: issuedVc});
-            const {result, error, statusCode} = await verifier.post(
-              {json: body});
-            shouldPassVerification({result, error, statusCode});
-          });
-        it('MUST update StatusList2021 revocation credential status and ' +
-          'fail to verify revoked credential', async function() {
-          this.test.cell = {columnId: verifierName, rowId: this.test.title};
-          // copy vc issued
-          const vc = klona(issuedVc);
-          // get the status of the VC
-          const statusInfo = await getCredentialStatus(
-            {verifiableCredential: vc});
-          statusInfo.status.should.equal(false);
-
-          // verification of the credential should pass
-          const {
-            result: result1,
-            error: err1,
-            statusCode: statusCode1
-          } = await verifier.post({json: createRequestBody({vc})});
-          shouldPassVerification(
-            {result: result1, error: err1, statusCode: statusCode1});
-          const setStatusList = setStatusLists.find(
-            issuer => issuer.tags.has('Revocation'));
-          // Then revoke the VC
-          const body = createRequestBody({
-            vc, setStatus: true, statusPurpose: 'revocation'});
-          const {
-            result: result2,
-            error: err2,
-            statusCode: statusCode2
-          } = await setStatusList.post({json: body});
-          should.not.exist(err2);
-          should.exist(result2);
-          statusCode2.should.equal(200);
-
-          const publishSlcEndpoint =
-            `${statusInfo.statusListCredential}/publish`;
-          const publishStatusList = publishStatusLists.find(
-            issuer => issuer.tags.has('Revocation'));
-
-          // force publication of new SLC
-          const {
-            result: result3,
-            error: err3,
-            statusCode: statusCode3
-          } = await publishStatusList.post({url: publishSlcEndpoint, json: {}});
-          should.not.exist(err3);
-          should.exist(result3);
-          statusCode3.should.equal(204);
-
-          // get the status of the VC
-          const {status} = await getCredentialStatus(
-            {verifiableCredential: vc});
-          status.should.equal(true);
-
-          // try to verify the credential again, should fail since it
-          // has now been revoked
-          const {
-            result: result4,
-            error: err4,
-            statusCode: statusCode4
-          } = await verifier.post({json: createRequestBody({vc})});
-          shouldFailVerification(
-            {result: result4, error: err4, statusCode: statusCode4});
+      for(const [verifierName, {endpoints}] of verifierMatches) {
+        const [verifier] = endpoints;
+        it(`${verifierName} should verify ${issuerName}`, async function() {
+          this.test.cell = {rowId: issuerName, columnId: verifierName};
+          const {data: vc, error: err} = await issuedVc;
+          should.not.exist(err);
+          should.exist(vc);
+          const body = createRequestBody({vc});
+          const {result, error, statusCode} = await verifier.post({json: body});
+          shouldPassVerification({result, error, statusCode});
         });
       }
     }
@@ -114,94 +52,30 @@ describe('StatusList2021 Credentials (Interop "statusPurpose: revocation")',
 
 describe('StatusList2021 Credentials (Interop "statusPurpose: suspension")',
   function() {
+    // this will tell the report
+    // to make an interop matrix with this suite
     this.matrix = true;
     this.report = true;
-    this.implemented = [...match.keys()];
-    this.rowLabel = 'Test Name';
-    this.columnLabel = 'Implementation';
-    for(const [
-      issuerName,
-      {issuers, setStatusLists, publishStatusLists}
-    ] of match) {
+    this.implemented = [...verifierMatches.keys()];
+    this.rowLabel = 'Issuer';
+    this.columnLabel = 'Verifier';
+    for(const [issuerName, {endpoints}] of issuerMatches) {
       let issuedVc;
       before(async function() {
-        const issuer = issuers.find(issuer => issuer.tags.has('Suspension'));
-        const credential = createValidVc({issuer});
-        const body = {credential};
-        const {data} = await issuer.post({json: body});
-        issuedVc = data;
+        const [issuer] = endpoints.filter(
+          endpoint => endpoint.settings.tags.includes('Suspension'));
+        issuedVc = issueVc({issuer});
       });
-      for(const [verifierName, {verifiers}] of match) {
-        const verifier = verifiers.find(verifier =>
-          verifier.tags.has('StatusList2021'));
-        it(`MUST successfully verify VC issued by ${issuerName}`,
-          async function() {
-            this.test.cell = {columnId: verifierName, rowId: this.test.title};
-            const body = createRequestBody({vc: issuedVc});
-            const {result, error, statusCode} = await verifier.post(
-              {json: body});
-            shouldPassVerification({result, error, statusCode});
-          });
-        it('MUST update StatusList2021 suspension credential status and ' +
-          'fail to verify suspended credential', async function() {
-          this.test.cell = {columnId: verifierName, rowId: this.test.title};
-          // copy vc issued
-          const vc = klona(issuedVc);
-          // get the status of the VC
-          const statusInfo = await getCredentialStatus(
-            {verifiableCredential: vc});
-          statusInfo.status.should.equal(false);
-
-          // verification of the credential should pass
-          const {
-            result: result1,
-            error: err1,
-            statusCode: statusCode1
-          } = await verifier.post({json: createRequestBody({vc})});
-          shouldPassVerification(
-            {result: result1, error: err1, statusCode: statusCode1});
-
-          const setStatusList = setStatusLists.find(
-            issuer => issuer.tags.has('Suspension'));
-          // Then suspend the VC
-          const body = createRequestBody({
-            vc, setStatus: true, statusPurpose: 'suspension'});
-          const {
-            result: result2,
-            error: err2,
-            statusCode: statusCode2
-          } = await setStatusList.post({json: body});
-          should.not.exist(err2);
-          should.exist(result2);
-          statusCode2.should.equal(200);
-          const publishSlcEndpoint =
-            `${statusInfo.statusListCredential}/publish`;
-          const publishStatusList = publishStatusLists.find(issuer =>
-            issuer.tags.has('Suspension'));
-          // force publication of new SLC
-          const {
-            result: result3,
-            error: err3,
-            statusCode: statusCode3
-          } = await publishStatusList.post({url: publishSlcEndpoint, json: {}});
-          should.not.exist(err3);
-          should.exist(result3);
-          statusCode3.should.equal(204);
-
-          // get the status of the VC
-          const {status} = await getCredentialStatus(
-            {verifiableCredential: vc});
-          status.should.equal(true);
-
-          // try to verify the credential again, should fail since it
-          // has now been revoked
-          const {
-            result: result4,
-            error: err4,
-            statusCode: statusCode4
-          } = await verifier.post({json: createRequestBody({vc})});
-          shouldFailVerification(
-            {result: result4, error: err4, statusCode: statusCode4});
+      for(const [verifierName, {endpoints}] of verifierMatches) {
+        const [verifier] = endpoints;
+        it(`${verifierName} should verify ${issuerName}`, async function() {
+          this.test.cell = {rowId: issuerName, columnId: verifierName};
+          const {data: vc, error: err} = await issuedVc;
+          should.not.exist(err);
+          should.exist(vc);
+          const body = createRequestBody({vc});
+          const {result, error, statusCode} = await verifier.post({json: body});
+          shouldPassVerification({result, error, statusCode});
         });
       }
     }


### PR DESCRIPTION
Also removes `not-implemented` and `node <= 16`. 